### PR TITLE
Rename settings commands

### DIFF
--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -75,7 +75,7 @@ public class SettingsCommandGroup : CommandGroup
     [RequireDiscordPermission(DiscordPermission.ManageGuild)]
     [Description("Shows settings list for this server")]
     [UsedImplicitly]
-    public async Task<Result> ExecuteSettingsListAsync(
+    public async Task<Result> ExecuteListSettingsAsync(
         [Description("Settings list page")] [MinValue(1)]
         int page)
     {
@@ -156,7 +156,7 @@ public class SettingsCommandGroup : CommandGroup
     [RequireDiscordPermission(DiscordPermission.ManageGuild)]
     [Description("Change settings for this server")]
     [UsedImplicitly]
-    public async Task<Result> ExecuteSettingsAsync(
+    public async Task<Result> ExecuteEditSettingsAsync(
         [Description("The setting whose value you want to change")]
         string setting,
         [Description("Setting value")] string value)

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -68,7 +68,7 @@ public class SettingsCommandGroup : CommandGroup
     /// <returns>
     ///     A feedback sending result which may or may not have succeeded.
     /// </returns>
-    [Command("settingslist")]
+    [Command("listsettings")]
     [DiscordDefaultMemberPermissions(DiscordPermission.ManageGuild)]
     [DiscordDefaultDMPermission(false)]
     [RequireContext(ChannelContext.Guild)]
@@ -76,8 +76,7 @@ public class SettingsCommandGroup : CommandGroup
     [Description("Shows settings list for this server")]
     [UsedImplicitly]
     public async Task<Result> ExecuteSettingsListAsync(
-        [Description("Settings list page")]
-        [MinValue(1)]
+        [Description("Settings list page")] [MinValue(1)]
         int page)
     {
         if (!_context.TryGetContextIDs(out var guildId, out _, out _))

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -149,7 +149,7 @@ public class SettingsCommandGroup : CommandGroup
     /// <param name="setting">The setting to modify.</param>
     /// <param name="value">The new value of the setting.</param>
     /// <returns>A feedback sending result which may or may not have succeeded.</returns>
-    [Command("settings")]
+    [Command("editsettings")]
     [DiscordDefaultMemberPermissions(DiscordPermission.ManageGuild)]
     [DiscordDefaultDMPermission(false)]
     [RequireContext(ChannelContext.Guild)]


### PR DESCRIPTION
This PR renames commands `/settingslist` and `/settings` to `/listsettings` and `/editsettings` respectively. This helps avoid confusion and accidental use of the wrong command while conforming to a common naming style, similar to remind commands.

cc @mctaylors wiki needs updating