### PR TITLE
Add periodic guild data saving (every 5 minutes)

### DIFF
--- a/src/Boyfriend.cs
+++ b/src/Boyfriend.cs
@@ -92,6 +92,7 @@ public sealed class Boyfriend
                         .AddHostedService<MemberUpdateService>()
                         .AddHostedService<ScheduledEventUpdateService>()
                         .AddHostedService<SongUpdateService>()
+                        .AddHostedService<BackgroundGuildDataSaverService>()
                         // Slash commands
                         .AddCommandTree()
                         .WithCommandGroup<AboutCommandGroup>()

--- a/src/Services/BackgroundGuildDataSaverService.cs
+++ b/src/Services/BackgroundGuildDataSaverService.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Boyfriend.Services;
+
+public sealed class BackgroundGuildDataSaverService : BackgroundService
+{
+    private readonly GuildDataService _guildData;
+
+    public BackgroundGuildDataSaverService(GuildDataService guildData)
+    {
+        _guildData = guildData;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMinutes(5));
+
+        while (await timer.WaitForNextTickAsync(ct))
+        {
+            await _guildData.SaveAsync(ct);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a BackgroundGuildDataSaverService which will save all guild data to disk every 5 minutes using a PeriodicTimer.

Closes #96 