### PR TITLE
Fix auto-unban and auto-unmute always triggering

### DIFF
--- a/src/Services/Update/MemberUpdateService.cs
+++ b/src/Services/Update/MemberUpdateService.cs
@@ -123,7 +123,7 @@ public sealed partial class MemberUpdateService : BackgroundService
     private async Task<Result> TryAutoUnbanAsync(
         Snowflake guildId, Snowflake id, MemberData data, CancellationToken ct)
     {
-        if (DateTimeOffset.UtcNow <= data.BannedUntil)
+        if (data.BannedUntil is null || DateTimeOffset.UtcNow <= data.BannedUntil)
         {
             return Result.FromSuccess();
         }
@@ -141,7 +141,7 @@ public sealed partial class MemberUpdateService : BackgroundService
     private async Task<Result> TryAutoUnmuteAsync(
         Snowflake guildId, Snowflake id, MemberData data, CancellationToken ct)
     {
-        if (DateTimeOffset.UtcNow <= data.MutedUntil)
+        if (data.MutedUntil is null || DateTimeOffset.UtcNow <= data.MutedUntil)
         {
             return Result.FromSuccess();
         }


### PR DESCRIPTION
Flipping `>` to `<=` changed null handling semantics within the operator, causing the unban/unmute code to always run